### PR TITLE
Cambios en docker-compose.yml para que el servicio sistemabiblioteca …

### DIFF
--- a/arrancar_sistemabiblioteca.sh
+++ b/arrancar_sistemabiblioteca.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+# Script para arrancar SistemaBiblioteca con Docker
+# Levanta MariaDB y SonarQube en segundo plano
+# y ejecuta sistemabiblioteca en modo interactivo
+
+# 1. Levantar servicios de soporte
+echo ">>> Levantando MariaDB y SonarQube en segundo plano..."
+docker-compose up -d mariadb sonarqube
+
+# 2. Construir la imagen de sistemabiblioteca
+echo ">>> Construyendo la imagen de sistemabiblioteca..."
+docker build -t sistemabiblioteca .
+
+# 3. Ejecutar sistemabiblioteca en modo interactivo
+echo ">>> Arrancando sistemabiblioteca en modo interactivo..."
+docker run -it --rm \
+  --name sistemabiblioteca \
+  --network=sistemabiblioteca_default \
+  sistemabiblioteca

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,6 @@
 version: "3.9"
 services:
+  #los servicios sonarqube y mariadb no necesitan interaccion con el usuario, se pueden levantar en segundo plano como servicios
   sonarqube:
     image: sonarqube:community
     container_name: sonarqube
@@ -23,15 +24,17 @@ services:
     ports:
       - "3306:3306"
 
-  sistemabiblioteca:
-    build: .
-    container_name: sistemabiblioteca
-    ports:
-      - "8081:8081"
-    depends_on:
-      - mariadb
-      - sonarqube
-    restart: always
+#sistemabiblioteca no se puede levantar asi porque necesitar interaccion con el usuario, que debe usar teclado y consola para moverse por la biblioteca.
+#se crea un script arrancar_sistemabiblioteca.sh para arrancar el sistemaBiblioteca
+#  sistemabiblioteca:
+#    build: .
+#    container_name: sistemabiblioteca
+#    ports:
+#      - "8081:8081"
+#    depends_on:
+#      - mariadb
+#      - sonarqube
+#    restart: always
 
 volumes:
   sonarqube_data:


### PR DESCRIPTION
…no se arranque en docker como un servicio en segundo plano

Se añade el script arrancar_sistemabiblioteca.sh para levantar los servicios de docker y poder lanzar el sistemaBiblioteca correctamente