### PR TITLE
Se añade script parar_sistemabiblioteca.sh para detener los contenedo…

### DIFF
--- a/parar_sistemabiblioteca.sh
+++ b/parar_sistemabiblioteca.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+echo "⏹️ Parando contenedor de sistemabiblioteca si está activo..."
+docker ps --filter "name=sistemabiblioteca" --format "{{.Names}}" | grep -q "sistemabiblioteca"
+if [ $? -eq 0 ]; then
+  docker stop sistemabiblioteca
+  echo "✅ Contenedor sistemabiblioteca detenido."
+else
+  echo "ℹ️ Contenedor sistemabiblioteca no estaba activo."
+fi
+
+echo "⏹️ Parando contenedores de MariaDB y SonarQube..."
+docker-compose down
+
+echo "✅ Todos los contenedores han sido detenidos correctamente."

--- a/src/main/java/com/example/biblioteca/component/BibliotecaCliRunner.java
+++ b/src/main/java/com/example/biblioteca/component/BibliotecaCliRunner.java
@@ -57,9 +57,14 @@ public class BibliotecaCliRunner implements CommandLineRunner {
                 case OPCION_REVISTA  -> consolaRevista.menuRevista();
                 case OPCION_PRESTAMO -> consolaPrestamo.menuPrestamo();
                 case OPCION_AUTOR    -> consolaAutor.menuAutor();
-                case OPCION_SALIR    -> System.out.println("---- !!! Hasta pronto !!! ----");
+                case OPCION_SALIR    -> salir();
                 default              -> commonService.mostrarError();
             }
         } while (!OPCION_SALIR.equals(opcion));
+    }
+
+    public void salir (){
+        System.out.println("---- !!! Hasta pronto !!! ----");
+        System.exit(0);
     }
 }


### PR DESCRIPTION
…res mariaDB y sonarQube al final del dia

SE modifica BibliotecaCliRunner.java para que en la salida del menu se haga un exit(0) y se cierre el contenedor de docker.